### PR TITLE
Support use with LTS 16.17.

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -27,7 +27,6 @@ dependencies:
 - vector
 - time
 - tagged
-- primitive
 - uuid
 - template-haskell
 - th-abstraction

--- a/servant-ts.cabal
+++ b/servant-ts.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 860783959b5616f318a984785d3e5c38a78fcade8f382d3f84aabb00cdf67dae
+-- hash: 85576b22fb608977dd52b078e9423fa2e61a928152b22637c6e2eb28ad02a2ae
 
 name:           servant-ts
 version:        0.1.0.0
@@ -40,7 +40,6 @@ library
       aeson
     , base >=4.7 && <5
     , containers
-    , primitive
     , recursion-schemes
     , servant
     , servant-foreign
@@ -67,7 +66,6 @@ executable servant-ts-examples
       aeson
     , base >=4.7 && <5
     , containers
-    , primitive
     , recursion-schemes
     , servant
     , servant-foreign
@@ -100,7 +98,6 @@ test-suite servant-ts-test
       aeson
     , base >=4.7 && <5
     , containers
-    , primitive
     , recursion-schemes
     , servant
     , servant-foreign

--- a/src/Servant/TS/Internal.hs
+++ b/src/Servant/TS/Internal.hs
@@ -34,11 +34,6 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Map.Lazy (Map)
 import qualified Data.Map.Lazy as Map
 import qualified Data.Monoid as Monoid
-import qualified Data.Primitive.Array as PM
-import qualified Data.Primitive.PrimArray as PM
-import qualified Data.Primitive.SmallArray as PM
-import qualified Data.Primitive.Types as PM
-import qualified Data.Primitive.UnliftedArray as PM
 import Data.Proxy
 import Data.Ratio (Ratio)
 {- import Data.Scientific (Scientific) -}
@@ -381,18 +376,6 @@ instance (TsTypeable a) => TsTypeable (HashSet a) where
 
 instance (TsTypeableKey k, TsTypeable v) => TsTypeable (HashMap k v) where
     tsTypeRep _ = makeMap (Proxy :: Proxy k) (Proxy :: Proxy v)
-
-instance (TsTypeable a) => TsTypeable (PM.Array a) where
-    tsTypeRep _ = TsArray (tsTypeRep (Proxy :: Proxy a))
-
-instance (TsTypeable a) => TsTypeable (PM.SmallArray a) where
-    tsTypeRep _ = TsArray (tsTypeRep (Proxy :: Proxy a))
-
-instance (TsTypeable a) => TsTypeable (PM.PrimArray a) where
-    tsTypeRep _ = TsArray (tsTypeRep (Proxy :: Proxy a))
-
-instance (TsTypeable a) => TsTypeable (PM.UnliftedArray a) where
-    tsTypeRep _ = TsArray (tsTypeRep (Proxy :: Proxy a))
 
 instance TsTypeable Day where
     tsTypeRep _ = TsString

--- a/src/Servant/TS/TH.hs
+++ b/src/Servant/TS/TH.hs
@@ -66,9 +66,6 @@ containsHKT hkts = f
           f (VarT x) =  Set.member (VarT x) hkts
           f _ = False
 
-instance Lift Text where
-    lift t = mkTextE (Text.unpack t)
-
 instance Lift ConName where
     lift (ConName p m n) = [| ConName |] `appE` (lift p) `appE` (lift m) `appE` (lift n)
 


### PR DESCRIPTION
* Data.Primitive.UnliftedArray has been removed from `primitive` and
added to a new package, `unlifted-primitive`. But I'm pretty sure we're
not using either of these packages, so I just removed them both.
* I guess `Lift` now already has an instance for `Text`. I'm not sure if
removing this loses backwards compatibility, but I don't think we need
to worry about that?