### PR TITLE
Wider missing argument check

### DIFF
--- a/src/Servant/TS/Gen.hs
+++ b/src/Servant/TS/Gen.hs
@@ -124,9 +124,9 @@ writeEndpoint opts t = do
                                in case at of
                                       Flag -> i' <> "if (" <> param <> " === true)\n" <>
                                               i' <> i' <> "$queryArgs.push(" <> quote n <> ");\n"
-                                      Normal -> i' <> "if (" <> param <> " !== undefined)\n" <>
+                                      Normal -> i' <> "if (" <> param <> " != null)\n" <>
                                                 i' <> i' <> "$queryArgs.push(" <> quote (n <> "=") <> " + encodeURIComponent(" <> writeStringCast param t <> "));\n"
-                                      List -> i' <> "if (" <> param <> " !== undefined)\n" <>
+                                      List -> i' <> "if (" <> param <> " != null)\n" <>
                                               i' <> i' <> "$queryArgs.push(..." <> param <> ".map(x => " <> quote (n <> "=") <> " + encodeURIComponent(" <> writeStringCast "x" t <> ")));\n"
 
     let queryPrepare = if null q then ""


### PR DESCRIPTION
This is necessary to type-check `restApi.ts` correctly for https://github.com/proda-ai/excelsior/pull/6078. An optional date argument is of type `string | null` but the check for a missing argument is `!== undefined`. It's likely there are better ways to do this.. but this seems to work.

![image](https://user-images.githubusercontent.com/49943297/96857290-b9177f80-1456-11eb-9a51-84afae1d33a3.png)
